### PR TITLE
Remote -it for unattended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM projectatomic/atomicapp:0.1.12
 MAINTAINER The BitScout Community <community@TBA>
 
 LABEL io.projectatomic.nulecule.providers="docker" \
-      io.projectatomic.nulecule.specversion="0.0.2"
+      io.projectatomic.nulecule.specversion="0.0.2" \
+      RUN="docker run --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} \${IMAGE}"
 
 ADD /Nulecule /Dockerfile /application-entity/
 #ADD /artifacts /application-entity/artifacts


### PR DESCRIPTION
When running in Jenkins without TTY we need to remove the `-it` option to the RUN label to suppress error "cannot enable tty mode on non tty input"
